### PR TITLE
Add basic Supabase auth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/debug-supabase.js
+++ b/debug-supabase.js
@@ -1,7 +1,7 @@
 // Debug script for browser console
 // Bu kodu browser console'da çalıştırarak Supabase bağlantısını test et
 
-async function debugSupabaseConnection() {
+export async function debugSupabaseConnection() {
     console.log('🔍 === SUPABASE DEBUG BAŞLADI ===');
     
     try {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { supabase } from './supabaseClient.js';
+
+export default function App() {
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSignUp = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      setMessage(error.message);
+      return;
+    }
+    const user = data.user;
+    if (user) {
+      const { error: insertError } = await supabase.from('users').insert({
+        auth_id: user.id,
+        first_name: firstName,
+        last_name: lastName
+      });
+      if (insertError) {
+        setMessage(insertError.message);
+        return;
+      }
+      setMessage('Sign up successful.');
+    } else {
+      setMessage('Check your email for confirmation.');
+    }
+  };
+
+  const handleSignIn = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setMessage(error.message);
+      return;
+    }
+    setMessage('Signed in successfully.');
+  };
+
+  return (
+    <div style={{ maxWidth: '420px', margin: '2rem auto', fontFamily: 'sans-serif' }}>
+      <h1>{isSignUp ? 'Sign Up' : 'Sign In'}</h1>
+      <form onSubmit={isSignUp ? handleSignUp : handleSignIn} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {isSignUp && (
+          <>
+            <input placeholder="First name" value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
+            <input placeholder="Last name" value={lastName} onChange={(e) => setLastName(e.target.value)} required />
+          </>
+        )}
+        <input type="email" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <button type="submit">{isSignUp ? 'Create account' : 'Sign in'}</button>
+      </form>
+      <button onClick={() => setIsSignUp(!isSignUp)} style={{ marginTop: '1rem' }}>
+        {isSignUp ? 'Have an account? Sign in' : 'Need an account? Sign up'}
+      </button>
+      {message && <p style={{ marginTop: '1rem' }}>{message}</p>}
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Missing Supabase credentials. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+import forms from '@tailwindcss/forms';
+import typography from '@tailwindcss/typography';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -151,7 +154,7 @@ export default {
     },
   },
   plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/typography'),
+    forms,
+    typography,
   ],
 }


### PR DESCRIPTION
## Summary
- add supabase client and simple React auth form that inserts new users in database
- document required Supabase env variables
- switch Tailwind config to ESM imports and export debug helper to keep lint clean

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f0b3ae4448328b76e86905ddd97e0